### PR TITLE
Update strings.xml

### DIFF
--- a/FlymFork/src/main/res/values/strings.xml
+++ b/FlymFork/src/main/res/values/strings.xml
@@ -120,8 +120,8 @@
     <string name="new_feed_title">New feed</string>
     <string name="context_menu_edit">Edit</string>
     <string name="menu_add_group">Add a group</string>
-    <string name="menu_import">Import from an OPML file</string>
-    <string name="menu_export">Export to an OPML file</string>
+    <string name="menu_import">Restore content sources and Favorites</string>
+    <string name="menu_export">Backup content sources and Favorites</string>
     <string name="storage_request_explanation">To be able to import or export the feeds from or to a file, you must allow the application to access to the storage memory.</string>
     <string name="error_feed_error">The feed website is unreachable.</string>
     <string name="error_feed_process">The feed can not be processed.</string>


### PR DESCRIPTION
It would be much more understandable what this function is for, especially for an average user.

I use _"content sources"_ instead of _"feeds"_ for the same reason: today I suppose most average users don't use this term, but will understand what does _"content source"_ mean.

I was thinking do we should include _"OPML"_ - and I think a file name will be enough for a user to figure out which file they should choose (if I remember well, this file have _"Handy"_ and _"Backup"_ in its name).

**So I propose this change for the app to be more user-friendly.**