### PR TITLE
Split Unread Articles notification from Long Operation

### DIFF
--- a/FlymFork/src/main/java/ru/yanus171/feedexfork/MainApplication.java
+++ b/FlymFork/src/main/java/ru/yanus171/feedexfork/MainApplication.java
@@ -55,6 +55,7 @@ public class MainApplication extends Application {
 
     public static final String OPERATION_NOTIFICATION_CHANNEL_ID = "operation_channel";
     public static final String READING_NOTIFICATION_CHANNEL_ID = "reading_channel";
+    public static final String UNREAD_NOTIFICATION_CHANNEL_ID = "unread_channel";
 
     @Override
     public void onCreate() {
@@ -93,6 +94,12 @@ public class MainApplication extends Application {
             {
                 NotificationChannel channel = new NotificationChannel(READING_NOTIFICATION_CHANNEL_ID, context.getString(R.string.reading_article), NotificationManager.IMPORTANCE_LOW);
                 channel.setDescription(context.getString(R.string.reading_article));
+                NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+                notificationManager.createNotificationChannel(channel);
+            }
+            {
+                NotificationChannel channel = new NotificationChannel(UNREAD_NOTIFICATION_CHANNEL_ID, context.getString(R.string.unread_article), NotificationManager.IMPORTANCE_HIGH);
+                channel.setDescription(context.getString(R.string.unread_article));
                 NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
                 notificationManager.createNotificationChannel(channel);
             }

--- a/FlymFork/src/main/java/ru/yanus171/feedexfork/service/FetcherService.java
+++ b/FlymFork/src/main/java/ru/yanus171/feedexfork/service/FetcherService.java
@@ -152,6 +152,7 @@ import static ru.yanus171.feedexfork.Constants.EXTRA_URI;
 import static ru.yanus171.feedexfork.Constants.GROUP_ID;
 import static ru.yanus171.feedexfork.Constants.URL_LIST;
 import static ru.yanus171.feedexfork.MainApplication.OPERATION_NOTIFICATION_CHANNEL_ID;
+import static ru.yanus171.feedexfork.MainApplication.UNREAD_NOTIFICATION_CHANNEL_ID;
 import static ru.yanus171.feedexfork.MainApplication.getContext;
 import static ru.yanus171.feedexfork.MainApplication.mImageFileVoc;
 import static ru.yanus171.feedexfork.fragment.EntriesListFragment.GetWhereSQL;
@@ -1443,7 +1444,10 @@ public class FetcherService extends IntentService {
                 .setContentTitle(getString(captionID)) //
                 .setLights(0xffffffff, 0, 0);
         if (Build.VERSION.SDK_INT >= 26 ) {
-            builder.setChannelId(OPERATION_NOTIFICATION_CHANNEL_ID);
+            if (ID == Constants.NOTIFICATION_ID_NEW_ITEMS_COUNT)
+                builder.setChannelId(UNREAD_NOTIFICATION_CHANNEL_ID);
+            else
+                builder.setChannelId(OPERATION_NOTIFICATION_CHANNEL_ID);
             if ( cancelPI != null )
                 builder.addAction(android.R.drawable.ic_menu_close_clear_cancel, getContext().getString(android.R.string.cancel), cancelPI);
         }

--- a/FlymFork/src/main/res/values/strings.xml
+++ b/FlymFork/src/main/res/values/strings.xml
@@ -509,6 +509,7 @@
     <string name="search_in_yandex">Search via Yandex</string>
     <string name="search_in_google">Search via Google</string>
     <string name="long_operation">Long operation</string>
+    <string name="unread_article">Unread Article(s)</string>
     <string name="reading_article">Reading an article</string>
     <string name="reading_notification">Article reading notification</string>
     <string name="reading_notification_descr">Persistent status bar notification to prevent app from being killed by system - to speed up app starting after long delay</string>


### PR DESCRIPTION
When following feeds that I want to be immediately alerted on when an unread item arrives, the only choice was change the settings on my phone for Long Operation.  
Unfortunately, Long Operation also goes off when refreshing feeds. So my phone was buzzing and chirping every minute.  

This splits Unread Articles into their own notification, so I am only buzzed and otherwise alerted when a new article appears on a feed I am auto-refreshing.